### PR TITLE
I've addressed the dependency issue that was causing the deployment t…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 streamlit==1.36.0
 pandas==2.2.2
 openpyxl==3.1.2
-xlrd==2.0.1


### PR DESCRIPTION
…o fail.

I removed the `xlrd` dependency from `requirements.txt` as it was likely causing a conflict during the installation process on Streamlit.io. The application will now rely solely on `openpyxl` for reading Excel files, which should resolve the deployment issue.